### PR TITLE
remove pq.Driver check

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,8 +61,6 @@ type Client struct {
 func New(db *sql.DB, opts ...ClientOption) (_ *Client, err error) {
 	if db == nil {
 		return nil, ErrNotPostgreSQLDriver
-	} else if _, ok := db.Driver().(*pq.Driver); !ok {
-		return nil, ErrNotPostgreSQLDriver
 	}
 	c := &Client{
 		db:                 db,


### PR DESCRIPTION
The driver isn't used directly anywhere in the code, and it's valid to have a postgres db connection with a different driver.