### PR TITLE
Avoid errors on duplicated create table calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *Client) CreateTable() error {
 }
 
 // DropTable cleans up a PostgreSQL DB from what was created in the CreateTable
-// function
+// function.
 func (c *Client) DropTable() error {
 	_, err := c.db.Exec("DROP TABLE " + c.tableName)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -116,16 +116,16 @@ func (c *Client) newLock(ctx context.Context, name string, opts []LockOption) *L
 }
 
 // CreateTable prepares a PostgreSQL table with the right DDL for it to be used
-// by this lock client. If the table already exists, it will return an error.
+// by this lock client. If the table already exists, it will do nothing.
 func (c *Client) CreateTable() error {
 	cmds := []string{
-		`CREATE TABLE ` + c.tableName + ` (
+		`CREATE TABLE IF NOT EXISTS ` + c.tableName + ` (
 			name CHARACTER VARYING(255) PRIMARY KEY,
 			record_version_number BIGINT,
 			data BYTEA,
 			owner CHARACTER VARYING(255)
 		);`,
-		`CREATE SEQUENCE ` + c.tableName + `_rvn OWNED BY ` + c.tableName + `.record_version_number`,
+		`CREATE SEQUENCE IF NOT EXISTS ` + c.tableName + `_rvn OWNED BY ` + c.tableName + `.record_version_number`,
 	}
 	for _, cmd := range cmds {
 		_, err := c.db.Exec(cmd)

--- a/client_test.go
+++ b/client_test.go
@@ -577,8 +577,8 @@ func TestCustomTable(t *testing.T) {
 		if err := c.CreateTable(); err != nil {
 			t.Fatal("cannot create table:", err)
 		}
-		if err := c.CreateTable(); err == nil {
-			t.Fatal("expected error not found")
+		if err := c.CreateTable(); err != nil {
+			t.Fatal("unexpected error on second create table call:", err)
 		}
 	})
 }


### PR DESCRIPTION
It might be easier for clients if `CreateTable` method didn't return an error when the table already exists. This way it can be safely put in service init code, and called each time on start.

@ucirello what do you think?