### PR TITLE
enable golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,12 @@ jobs:
       with:
         go-version: 'stable'
 
+    - name: Setup golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        # actions/setup-go@v4 introduced automatic cache handling so skip cache here
+        skip-cache: true
+
     - name: Test
       run: |
         go test -coverprofile=coverage.out -shuffle on -short -v -dsn="postgres://postgres:everyone@localhost:5432/postgres?sslmode=disable" || (sleep 5; go test -coverprofile=coverage.out -shuffle on -short -v -dsn="postgres://postgres:everyone@localhost:5432/postgres?sslmode=disable")

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+linters:
+  disable:
+    - errcheck
+    - ineffassign 
+    - govet
+    - staticcheck
+    - unused
+  enable:
+    - gci
+    - gocritic
+    - gofumpt
+    - misspell
+    - revive
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(cirello.io/pglock)

--- a/client.go
+++ b/client.go
@@ -184,10 +184,11 @@ func (c *Client) AcquireContext(ctx context.Context, name string, opts ...LockOp
 			return nil, ErrNotAcquired
 		default:
 			err := c.retry(ctx, func() error { return c.tryAcquire(ctx, l) })
-			if l.failIfLocked && err == ErrNotAcquired {
+			switch {
+			case l.failIfLocked && err == ErrNotAcquired:
 				c.log.Println("not acquired, exit")
 				return l, err
-			} else if err == ErrNotAcquired {
+			case err == ErrNotAcquired:
 				c.log.Println("not acquired, wait:", l.leaseDuration)
 				select {
 				case <-time.After(l.leaseDuration):
@@ -195,7 +196,7 @@ func (c *Client) AcquireContext(ctx context.Context, name string, opts ...LockOp
 					return l, err
 				}
 				continue
-			} else if err != nil {
+			case err != nil:
 				c.log.Println("error:", err)
 				return nil, err
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -30,10 +30,11 @@ import (
 	"testing"
 	"time"
 
-	"cirello.io/pglock"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
+
+	"cirello.io/pglock"
 )
 
 type fakeDriver struct{}
@@ -246,7 +247,6 @@ func TestOpen(t *testing.T) {
 			t.Fatal("got unexpected error when the client was misconfigured")
 		}
 	})
-
 }
 
 func TestFailIfLocked(t *testing.T) {
@@ -1137,7 +1137,7 @@ func parallelAcquire(t testing.TB, maxConcurrency int) {
 	case err := <-errCh:
 		// If the context is cancelled its likely we will get a lot of
 		// errors of in flight operations. We don't care about those so
-		// we will not Fail on any error that occured after context
+		// we will not Fail on any error that occurred after context
 		// cancellation
 		if ctx.Err() != nil {
 			return

--- a/doc.go
+++ b/doc.go
@@ -23,59 +23,57 @@ limitations under the License.
 //
 // Basic usage:
 //
-// 	db, err := sql.Open("postgres", *dsn)
-// 	if err != nil {
-// 		log.Fatal("cannot connect to test database server:", err)
-// 	}
-// 	name := randStr(32)
-// 	c, err := pglock.New(db)
-// 	if err != nil {
-// 		log.Fatal("cannot create lock client:", err)
-// 	}
-// 	l1, err := c.Acquire(name)
-// 	if err != nil {
-// 		log.Fatal("unexpected error while acquiring 1st lock:", err)
-// 	}
-// 	t.Log("acquired first lock")
-// 	var wg sync.WaitGroup
-// 	wg.Add(1)
-// 	var locked bool
-// 	go func() {
-// 		defer wg.Done()
-// 		l2, err := c.Acquire(name)
-// 		if err != nil {
-// 			log.Fatal("unexpected error while acquiring 2nd lock:", err)
-// 		}
-// 		t.Log("acquired second lock")
-// 		locked = true
-// 		l2.Close()
-// 	}()
-// 	time.Sleep(6 * time.Second)
-// 	l1.Close()
-// 	wg.Wait()
+//	db, err := sql.Open("postgres", *dsn)
+//	if err != nil {
+//		log.Fatal("cannot connect to test database server:", err)
+//	}
+//	name := randStr(32)
+//	c, err := pglock.New(db)
+//	if err != nil {
+//		log.Fatal("cannot create lock client:", err)
+//	}
+//	l1, err := c.Acquire(name)
+//	if err != nil {
+//		log.Fatal("unexpected error while acquiring 1st lock:", err)
+//	}
+//	t.Log("acquired first lock")
+//	var wg sync.WaitGroup
+//	wg.Add(1)
+//	var locked bool
+//	go func() {
+//		defer wg.Done()
+//		l2, err := c.Acquire(name)
+//		if err != nil {
+//			log.Fatal("unexpected error while acquiring 2nd lock:", err)
+//		}
+//		t.Log("acquired second lock")
+//		locked = true
+//		l2.Close()
+//	}()
+//	time.Sleep(6 * time.Second)
+//	l1.Close()
+//	wg.Wait()
 //
 // pglock.Client.Do can be used for long-running processes:
 //
-// 	err = c.Do(context.Background(), name, func(ctx context.Context, l *pglock.Lock) error {
-// 		once := make(chan struct{}, 1)
-// 		once <- struct{}{}
-// 		for {
-// 			select {
-// 			case <-ctx.Done():
-// 				t.Log("context canceled")
-// 				return ctx.Err()
-// 			case <-once:
-// 				t.Log("executed once")
-// 				close(ranOnce)
-// 			}
-// 		}
-// 	})
-// 	if err != nil && err != context.Canceled {
-// 		log.Fatal("unexpected error while running under lock:", err)
-// 	}
-//
+//	err = c.Do(context.Background(), name, func(ctx context.Context, l *pglock.Lock) error {
+//		once := make(chan struct{}, 1)
+//		once <- struct{}{}
+//		for {
+//			select {
+//			case <-ctx.Done():
+//				t.Log("context canceled")
+//				return ctx.Err()
+//			case <-once:
+//				t.Log("executed once")
+//				close(ranOnce)
+//			}
+//		}
+//	})
+//	if err != nil && err != context.Canceled {
+//		log.Fatal("unexpected error while running under lock:", err)
+//	}
 //
 // This package is covered by this SLA:
 // https://github.com/cirello-io/public/blob/master/SLA.md
-//
 package pglock // import "cirello.io/pglock"


### PR DESCRIPTION
Enable golangci-lint with the following linters:
- gci
- gocritic
- gofumpt
- misspell
- revive

I had to disable several linters so they can be addressed later:
- errcheck
- ineffassign 
- govet
- staticcheck
- unused

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>