### PR TITLE
feat: Add support for `pgxpool`

### DIFF
--- a/client.go
+++ b/client.go
@@ -246,6 +246,7 @@ func (c *Client) storeAcquire(ctx context.Context, l *Lock) error {
 	if err != nil {
 		return typedError(err, "cannot create transaction for lock acquisition")
 	}
+	defer tx.Rollback()
 	c.log.Debug("storeAcquire in: %v %v %v %v", l.name, rvn, l.data, l.recordVersionNumber)
 	defer func() {
 		c.log.Debug("storeAcquire out: %v %v %v %v", l.name, rvn, l.data, l.recordVersionNumber)
@@ -335,6 +336,8 @@ func (c *Client) storeRelease(ctx context.Context, l *Lock) error {
 	if err != nil {
 		return typedError(err, "cannot create transaction for lock acquisition")
 	}
+	defer tx.Rollback()
+
 	result, err := tx.ExecContext(ctx, `
 		UPDATE
 			`+c.tableName+`
@@ -415,6 +418,8 @@ func (c *Client) storeHeartbeat(ctx context.Context, l *Lock) error {
 	if err != nil {
 		return typedError(err, "cannot create transaction for lock acquisition")
 	}
+	defer tx.Rollback()
+
 	result, err := tx.ExecContext(ctx, `
 		UPDATE
 			`+c.tableName+`

--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 )
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -109,7 +109,7 @@ func TestDBErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatal("cannot create mock:", err)
 		}
-		client.db = db
+		client.db = FromSQLDB(db)
 		ctx, cancel := context.WithCancel(context.Background())
 		return client, mock, &Lock{
 			heartbeatContext: ctx,

--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"cirello.io/pglock"
-	_ "github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -81,6 +81,7 @@ func setupCustomDB(t *testing.T, driver string, options ...pglock.ClientOption) 
 	if err != nil {
 		t.Fatal("cannot connect to test database server:", err)
 	}
+
 	c, err := pglock.UnsafeNew(db, append([]pglock.ClientOption{pglock.WithCustomTable(tableName)}, options...)...)
 	if err != nil {
 		t.Fatal("cannot connect:", err)

--- a/db.go
+++ b/db.go
@@ -16,6 +16,7 @@ type sqlLike interface {
 type txLike interface {
 	ExecContext(ctx context.Context, sql string, arguments ...any) (resultLike, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) rowLike
+	Rollback() error
 	Commit() error
 }
 

--- a/db.go
+++ b/db.go
@@ -1,0 +1,35 @@
+package pglock
+
+import (
+	"context"
+	"database/sql"
+)
+
+type sqlLike interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (txLike, error)
+	Exec(sql string, arguments ...any) (any, error)
+	QueryContext(ctx context.Context, query string, args ...any) (rowsLike, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) rowLike
+	Close() error
+}
+
+type txLike interface {
+	ExecContext(ctx context.Context, sql string, arguments ...any) (resultLike, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) rowLike
+	Commit() error
+}
+
+type rowLike interface {
+	Scan(dest ...any) error
+}
+
+type rowsLike interface {
+	rowLike
+	Close() error
+	Next() bool
+	Err() error
+}
+
+type resultLike interface {
+	RowsAffected() (int64, error)
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.2 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.14.1 // indirect
+	github.com/jackc/puddle v1.3.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module cirello.io/pglock
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/jackc/pgx/v4 v4.18.1
+	github.com/jackc/pgx/v5 v5.5.2
 	github.com/lib/pq v1.10.9
 	golang.org/x/sync v0.6.0
 )
@@ -16,6 +16,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.14.1 // indirect
 	github.com/jackc/puddle v1.3.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzk
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/go.sum
+++ b/go.sum
@@ -63,11 +63,15 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.18.1 h1:YP7G1KABtKpB5IHrO9vYwSrCOhs7p3uqhvhhQBptya0=
 github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzkb+qQE=
+github.com/jackc/pgx/v5 v5.5.2 h1:iLlpgp4Cp/gC9Xuscl7lFL1PhhW+ZLtXZcrfCt4C3tA=
+github.com/jackc/pgx/v5 v5.5.2/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/interop.go
+++ b/interop.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func FromSQLDB(db *sql.DB) *sqldbWrapper {

--- a/interop.go
+++ b/interop.go
@@ -1,0 +1,139 @@
+package pglock
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+func FromSQLDB(db *sql.DB) *sqldbWrapper {
+	return &sqldbWrapper{
+		DB: db,
+	}
+}
+
+var (
+	_ sqlLike = (*sqldbWrapper)(nil)
+	_ txLike  = (*sqlTxWrapper)(nil)
+)
+
+type sqldbWrapper struct {
+	*sql.DB
+}
+
+func (s *sqldbWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (txLike, error) {
+	t, err := s.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlTxWrapper{Tx: t}, nil
+}
+
+func (s *sqldbWrapper) Exec(sql string, arguments ...any) (any, error) {
+	return s.DB.Exec(sql, arguments...)
+}
+
+func (s *sqldbWrapper) QueryRowContext(ctx context.Context, query string, args ...any) rowLike {
+	return s.DB.QueryRowContext(ctx, query, args...)
+}
+
+func (s *sqldbWrapper) QueryContext(ctx context.Context, query string, args ...any) (rowsLike, error) {
+	return s.DB.QueryContext(ctx, query, args...)
+}
+
+type sqlTxWrapper struct {
+	*sql.Tx
+}
+
+func (t *sqlTxWrapper) ExecContext(ctx context.Context, sql string, arguments ...any) (resultLike, error) {
+	return t.Tx.ExecContext(ctx, sql, arguments...)
+}
+
+func (t *sqlTxWrapper) QueryRowContext(ctx context.Context, query string, args ...any) rowLike {
+	return t.Tx.QueryRowContext(ctx, query, args...)
+}
+
+func FromPGXPool(db *pgxpool.Pool) *pgxpoolWrapper {
+	return &pgxpoolWrapper{
+		Pool: db,
+	}
+}
+
+var (
+	_ sqlLike    = (*pgxpoolWrapper)(nil)
+	_ txLike     = (*pgxTxWrapper)(nil)
+	_ resultLike = (*pgxResultWrapper)(nil)
+)
+
+type pgxpoolWrapper struct {
+	*pgxpool.Pool
+}
+
+func (s *pgxpoolWrapper) BeginTx(ctx context.Context, opts *sql.TxOptions) (txLike, error) {
+	if opts.Isolation != sql.LevelSerializable {
+		return nil, errors.New("pglock: pgxpoolWrapper only supports serializable isolation")
+	}
+
+	tx, err := s.Pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.Serializable,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &pgxTxWrapper{Tx: tx}, nil
+}
+
+func (s *pgxpoolWrapper) Exec(sql string, arguments ...any) (any, error) {
+	return s.Pool.Exec(context.Background(), sql, arguments...)
+}
+
+func (s *pgxpoolWrapper) QueryContext(ctx context.Context, query string, args ...any) (rowsLike, error) {
+	r, err := s.Pool.Query(ctx, query, args...)
+	return &pgxRowsWrapper{Rows: r}, err
+}
+
+func (s *pgxpoolWrapper) QueryRowContext(ctx context.Context, query string, args ...any) rowLike {
+	return s.Pool.QueryRow(ctx, query, args...)
+}
+
+func (s *pgxpoolWrapper) Close() error {
+	return nil
+}
+
+type pgxTxWrapper struct {
+	pgx.Tx
+}
+
+func (t *pgxTxWrapper) ExecContext(ctx context.Context, sql string, arguments ...any) (resultLike, error) {
+	ct, err := t.Tx.Exec(ctx, sql, arguments...)
+	return &pgxResultWrapper{CommandTag: &ct}, err
+}
+
+func (t *pgxTxWrapper) QueryRowContext(ctx context.Context, query string, args ...any) rowLike {
+	return t.Tx.QueryRow(ctx, query, args...)
+}
+
+func (t *pgxTxWrapper) Commit() error {
+	return t.Tx.Commit(context.Background())
+}
+
+type pgxRowsWrapper struct {
+	pgx.Rows
+}
+
+func (p *pgxRowsWrapper) Close() error {
+	p.Rows.Close()
+	return nil
+}
+
+type pgxResultWrapper struct {
+	*pgconn.CommandTag
+}
+
+func (r *pgxResultWrapper) RowsAffected() (int64, error) {
+	return r.CommandTag.RowsAffected(), nil
+}

--- a/interop.go
+++ b/interop.go
@@ -110,7 +110,7 @@ type pgxTxWrapper struct {
 
 func (t *pgxTxWrapper) ExecContext(ctx context.Context, sql string, arguments ...any) (resultLike, error) {
 	ct, err := t.Tx.Exec(ctx, sql, arguments...)
-	return &pgxResultWrapper{CommandTag: &ct}, err
+	return &pgxResultWrapper{CommandTag: ct}, err
 }
 
 func (t *pgxTxWrapper) QueryRowContext(ctx context.Context, query string, args ...any) rowLike {
@@ -119,6 +119,10 @@ func (t *pgxTxWrapper) QueryRowContext(ctx context.Context, query string, args .
 
 func (t *pgxTxWrapper) Commit() error {
 	return t.Tx.Commit(context.Background())
+}
+
+func (t *pgxTxWrapper) Rollback() error {
+	return t.Tx.Rollback(context.Background())
 }
 
 type pgxRowsWrapper struct {
@@ -131,7 +135,7 @@ func (p *pgxRowsWrapper) Close() error {
 }
 
 type pgxResultWrapper struct {
-	*pgconn.CommandTag
+	pgconn.CommandTag
 }
 
 func (r *pgxResultWrapper) RowsAffected() (int64, error) {


### PR DESCRIPTION
Adds support for using `pgxpool.Pool` instead of `sql.DB`. Adds these functions:

```go
func NewPGXPool(db *pgxpool.Pool, opts ...ClientOption) (*Client, error)
func UnsafeGenericNew(db sqlLike, opts ...ClientOption) (*Client, error)

func FromSQLDB(db *sql.DB) *sqldbWrapper
func FromPGXPool(db *pgxpool.Pool) *pgxpoolWrapper
```


Implements #82 